### PR TITLE
Fix MessageInputView on iPhone X

### DIFF
--- a/Palmerah/MessageInputView.swift
+++ b/Palmerah/MessageInputView.swift
@@ -65,8 +65,12 @@ class MessageInputView: UIView, UITextViewDelegate {
         addSubview(sendMessageButton)
         
         addConstraintWithFormat(format: "H:|-8-[v0][v1(60)]|", views: inputTextView, sendMessageButton)
-        addConstraintWithFormat(format: "V:|-6-[v0]-6-|", views: inputTextView)
-        addConstraintWithFormat(format: "V:|[v0]|", views: sendMessageButton)
+        
+        inputTextView.topAnchor.constraint(equalTo: self.topAnchor, constant: 6).isActive = true
+        inputTextView.bottomAnchor.constraint(equalTo: self.layoutMarginsGuide.bottomAnchor, constant: -6).isActive = true
+        
+        sendMessageButton.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+        sendMessageButton.bottomAnchor.constraint(equalTo: self.layoutMarginsGuide.bottomAnchor).isActive = true
         
         // Disabling textView scrolling prevents some undesired effects,
         // like incorrect contentOffset when adding new line,


### PR DESCRIPTION
Before :

<img width="570" alt="capture d ecran 2017-10-01 a 11 46 23" src="https://user-images.githubusercontent.com/3055394/31053482-630e97fa-a69e-11e7-983d-68d142f3e15b.png">

After :

<img width="570" alt="capture d ecran 2017-10-01 a 11 47 14" src="https://user-images.githubusercontent.com/3055394/31053481-62eb863e-a69e-11e7-9a60-92a47ae88d67.png">

**EDIT**: I think this is better than the solution you explain here : https://bobbyprabowo.com/post/inputaccessoryview-on-ios-11/